### PR TITLE
Remove bloat from connected_components split_ccs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 bin*/
+build*/
 *.code-workspace
 .vscode/
-build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin*/
 *.code-workspace
 .vscode/
+build/

--- a/include/quiver/connected_components.hpp
+++ b/include/quiver/connected_components.hpp
@@ -43,13 +43,13 @@ namespace quiver
 	split_ccs(adjacency_list<dir, edge_properties_t, vertex_properties_t, out_edge_container, vertex_container> const& graph)
 	{
 		using graph_t = adjacency_list<dir, edge_properties_t, vertex_properties_t, out_edge_container, vertex_container>;
-		auto ds = get_disjoint_set(graph);										// vertex [0..V] -> root [0..V]
+		auto ds = get_disjoint_set(graph);									// vertex [0..V] -> root [0..V]
 
-		std::unordered_map<vertex_index_t, vertex_index_t> compressed_cc_index; // disjoint set roots -> cc index [0..|CC|]
+		std::unordered_map<std::size_t, std::size_t> compressed_cc_index;	// disjoint set roots -> cc index [0..|CC|]
 		for(vertex_index_t v = 0; v < graph.V(); ++v)
 			compressed_cc_index.try_emplace(ds.find(v), compressed_cc_index.size());
 
-		std::vector<std::size_t> cc_relative(graph.V());						// vertex [0..V] -> index in cc [0..V-|CC|+1]
+		std::vector<std::size_t> cc_relative(graph.V());					// vertex [0..V] -> index in cc [0..V-|CC|+1]
 		{
 			std::vector<std::size_t> counters(ds.sets(), 0);
 			for(vertex_index_t v = 0; v < graph.V(); ++v)

--- a/include/quiver/connected_components.hpp
+++ b/include/quiver/connected_components.hpp
@@ -43,18 +43,13 @@ namespace quiver
 	split_ccs(adjacency_list<dir, edge_properties_t, vertex_properties_t, out_edge_container, vertex_container> const& graph)
 	{
 		using graph_t = adjacency_list<dir, edge_properties_t, vertex_properties_t, out_edge_container, vertex_container>;
-		auto ds = get_disjoint_set(graph);					// vertex [0..V] -> root [0..V]
+		auto ds = get_disjoint_set(graph);										// vertex [0..V] -> root [0..V]
 
 		std::unordered_map<vertex_index_t, vertex_index_t> compressed_cc_index; // disjoint set roots -> cc index [0..|CC|]
-		{
-			for(vertex_index_t v = 0; v < graph.V(); ++v) {
-				vertex_index_t parent_v = ds.find(v);
-				if(compressed_cc_index.count(parent_v) == 0)
-					compressed_cc_index.emplace(parent_v, compressed_cc_index.size());
-			}
-		}
+		for(vertex_index_t v = 0; v < graph.V(); ++v)
+			compressed_cc_index.try_emplace(ds.find(v), compressed_cc_index.size());
 
-		std::vector<std::size_t> cc_relative(graph.V());	// vertex [0..V] -> index in cc [0..V-|CC|+1]
+		std::vector<std::size_t> cc_relative(graph.V());						// vertex [0..V] -> index in cc [0..V-|CC|+1]
 		{
 			std::vector<std::size_t> counters(ds.sets(), 0);
 			for(vertex_index_t v = 0; v < graph.V(); ++v)


### PR DESCRIPTION
You need an unordered map anyway, so there's no point in converting it to a vector first, just use the unordered_map later.